### PR TITLE
Integrate Python RAG service and wire into NestJS chatbot (with e2e test)

### DIFF
--- a/tenant_portal_backend/chatbot/Dockerfile
+++ b/tenant_portal_backend/chatbot/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY chatbot/requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt
+
+COPY __init__.py /app/tenant_portal_backend/__init__.py
+COPY chatbot /app/tenant_portal_backend/chatbot
+
+ENV PYTHONPATH=/app
+
+EXPOSE 9000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:9000/health')" || exit 1
+
+CMD ["uvicorn", "tenant_portal_backend.chatbot.service:app", "--host", "0.0.0.0", "--port", "9000"]

--- a/tenant_portal_backend/chatbot/requirements.txt
+++ b/tenant_portal_backend/chatbot/requirements.txt
@@ -1,0 +1,2 @@
+fastapi>=0.104.1
+uvicorn[standard]>=0.24.0

--- a/tenant_portal_backend/chatbot/service.py
+++ b/tenant_portal_backend/chatbot/service.py
@@ -1,0 +1,46 @@
+"""FastAPI wrapper for the tenant chatbot RAG pipeline."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from .manager import ConversationManager
+
+app = FastAPI(title="Tenant Chatbot RAG Service", version="1.0.0")
+manager = ConversationManager()
+
+
+class ChatRequest(BaseModel):
+    user_id: str
+    message: str
+
+
+class ChatResponse(BaseModel):
+    session_id: str
+    intent: str
+    workflow: Optional[str]
+    response: Dict[str, Any]
+    documents: List[str]
+    history_length: Optional[int] = None
+
+
+@app.get("/health")
+def health_check() -> Dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/message", response_model=ChatResponse)
+def handle_message(request: ChatRequest) -> Dict[str, Any]:
+    try:
+        return manager.handle_message(request.user_id, request.message)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("tenant_portal_backend.chatbot.service:app", host="0.0.0.0", port=9000, reload=False)

--- a/tenant_portal_backend/src/chatbot/chatbot.service.ts
+++ b/tenant_portal_backend/src/chatbot/chatbot.service.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '../prisma/prisma.service';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import OpenAI from 'openai';
+import axios from 'axios';
 import { randomUUID } from 'crypto';
 import {
   routePropertyOpsOrchestrator,
@@ -32,11 +33,25 @@ export interface ChatbotSession {
   updatedAt: Date;
 }
 
+interface RagServiceResponse {
+  session_id: string;
+  intent: string;
+  workflow?: string | null;
+  response: Record<string, any>;
+  documents: string[];
+  history_length?: number;
+}
+
 export interface ChatbotResponse {
   message: string;
   sessionId: string;
   intent?: string;
   confidence?: number;
+  rag_session_id?: string;
+  rag_intent?: string;
+  rag_workflow?: string | null;
+  rag_documents?: string[];
+  rag_response?: Record<string, any>;
   suggestedActions?: Array<{
     label: string;
     action: string;
@@ -52,6 +67,9 @@ export class ChatbotService {
   private openai: OpenAI | null = null;
   private readonly aiEnabled: boolean;
   private readonly propertyOpsOrchestratorEnabled: boolean;
+  private readonly ragEnabled: boolean;
+  private readonly ragServiceUrl: string;
+  private readonly ragTimeoutMs: number;
   private readonly sessions: Map<string, ChatbotSession> = new Map();
 
   constructor(
@@ -65,9 +83,15 @@ export class ChatbotService {
       'AI_PROPERTY_OPS_ORCHESTRATOR_ENABLED',
       'true',
     ) === 'true';
+    const ragEnabled = this.configService.get<string>('AI_RAG_ENABLED', 'false') === 'true';
+    const ragServiceUrl = this.configService.get<string>('AI_RAG_SERVICE_URL', 'http://localhost:9000');
+    const ragTimeoutMs = Number(this.configService.get<string>('AI_RAG_TIMEOUT_MS', '2500'));
 
     this.aiEnabled = aiEnabled && chatbotEnabled;
     this.propertyOpsOrchestratorEnabled = orchestratorEnabled;
+    this.ragEnabled = ragEnabled;
+    this.ragServiceUrl = ragServiceUrl;
+    this.ragTimeoutMs = Number.isFinite(ragTimeoutMs) ? ragTimeoutMs : 2500;
 
     if (this.aiEnabled && apiKey) {
       this.openai = new OpenAI({ apiKey });
@@ -75,6 +99,12 @@ export class ChatbotService {
     } else {
       this.logger.warn(
         'Chatbot Service initialized in mock mode (no OpenAI API key or AI disabled)',
+      );
+    }
+
+    if (this.ragEnabled) {
+      this.logger.log(
+        `RAG service integration enabled. URL: ${this.ragServiceUrl}, timeout: ${this.ragTimeoutMs}ms`,
       );
     }
   }
@@ -89,6 +119,7 @@ export class ChatbotService {
   ): Promise<ChatbotResponse> {
     const startTime = Date.now();
     let user: any;
+    let ragPayload: RagServiceResponse | null = null;
 
     try {
       // Pull user context early for routing + prompts.
@@ -117,6 +148,10 @@ export class ChatbotService {
         timestamp: new Date(),
       });
 
+      if (this.ragEnabled) {
+        ragPayload = await this.fetchRagResponse(userId, message);
+      }
+
       // Generate AI response
       let aiResponse: string;
       let intent: string | undefined;
@@ -126,14 +161,23 @@ export class ChatbotService {
       const traceId = this.generateTraceId();
 
       if (this.openai && this.aiEnabled) {
-        const response = await this.generateAIResponse(session, message, user);
+        const response = await this.generateAIResponse(
+          session,
+          message,
+          user,
+          ragPayload ? this.buildRagContext(ragPayload) : undefined,
+        );
         aiResponse = response.content;
         intent = response.intent;
         confidence = response.confidence;
       } else {
         // Fallback to simple responses
-        aiResponse = this.generateFallbackResponse(message);
+        aiResponse = ragPayload?.response?.content || this.generateFallbackResponse(message);
         confidence = 0.5;
+      }
+
+      if (!intent && ragPayload?.intent) {
+        intent = ragPayload.intent;
       }
 
       orchestrator = routePropertyOpsOrchestrator({
@@ -202,13 +246,21 @@ export class ChatbotService {
       });
 
       // Generate suggested actions based on intent
-      const suggestedActions = this.generateSuggestedActions(intent, message);
+      const suggestedActions = this.mergeSuggestedActions([
+        ...(ragPayload?.workflow ? this.generateWorkflowActions(ragPayload.workflow) : []),
+        ...this.generateSuggestedActions(intent, message),
+      ]);
 
       return {
         message: aiResponse,
         sessionId: session.id,
         intent,
         confidence,
+        rag_session_id: ragPayload?.session_id,
+        rag_intent: ragPayload?.intent,
+        rag_workflow: ragPayload?.workflow,
+        rag_documents: ragPayload?.documents,
+        rag_response: ragPayload?.response,
         suggestedActions,
         orchestrator,
         orchestrator_run: orchestratorRun,
@@ -241,6 +293,7 @@ export class ChatbotService {
     session: ChatbotSession,
     userMessage: string,
     userContext?: any,
+    ragContext?: string,
   ): Promise<{ content: string; intent?: string; confidence?: number }> {
     if (!this.openai) {
       throw new Error('OpenAI client not initialized');
@@ -281,6 +334,10 @@ Be friendly, professional, and concise. Provide actionable information when poss
 - Property: ${user.lease.unit?.property?.name || 'N/A'}
 - Unit: ${user.lease.unit?.unitNumber || 'N/A'}
 - Rent: $${user.lease.rentAmount || 0}/month`;
+    }
+
+    if (ragContext) {
+      systemPrompt += `\n\nKnowledge base context:\n${ragContext}`;
     }
 
     // Build conversation history (last 10 messages for context)
@@ -326,6 +383,21 @@ Be friendly, professional, and concise. Provide actionable information when poss
       intent,
       confidence: 0.9, // High confidence for AI responses
     };
+  }
+
+  private buildRagContext(ragPayload: RagServiceResponse): string {
+    const sections: string[] = [];
+    if (ragPayload.documents?.length) {
+      sections.push(`Relevant documents: ${ragPayload.documents.join(', ')}`);
+    }
+    const ragContent = ragPayload.response?.content;
+    if (ragContent) {
+      sections.push(`Draft response: ${ragContent}`);
+    }
+    if (ragPayload.workflow) {
+      sections.push(`Suggested workflow: ${ragPayload.workflow}`);
+    }
+    return sections.join('\n');
   }
 
   /**
@@ -400,6 +472,39 @@ Be friendly, professional, and concise. Provide actionable information when poss
     return actions;
   }
 
+  private generateWorkflowActions(
+    workflow: string,
+  ): Array<{ label: string; action: string; params?: Record<string, any> }> {
+    switch (workflow) {
+      case 'maintenance_request':
+        return [
+          { label: 'Submit Maintenance Request', action: 'navigate', params: { path: '/maintenance/new' } },
+        ];
+      case 'rent_reminder':
+        return [{ label: 'View Payments', action: 'navigate', params: { path: '/payments' } }];
+      case 'renewal_offer':
+        return [{ label: 'View Lease', action: 'navigate', params: { path: '/lease' } }];
+      default:
+        return [];
+    }
+  }
+
+  private mergeSuggestedActions(
+    actions: Array<{ label: string; action: string; params?: Record<string, any> }>,
+  ): Array<{ label: string; action: string; params?: Record<string, any> }> {
+    const seen = new Set<string>();
+    const merged: Array<{ label: string; action: string; params?: Record<string, any> }> = [];
+    for (const action of actions) {
+      const key = JSON.stringify({ action: action.action, params: action.params });
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      merged.push(action);
+    }
+    return merged;
+  }
+
   /**
    * Generate fallback response when AI is not available
    */
@@ -419,6 +524,22 @@ Be friendly, professional, and concise. Provide actionable information when poss
     }
 
     return 'I\'m here to help! I can assist you with maintenance requests, payments, lease questions, and more. What would you like to know?';
+  }
+
+  private async fetchRagResponse(userId: string, message: string): Promise<RagServiceResponse | null> {
+    try {
+      const response = await axios.post<RagServiceResponse>(
+        `${this.ragServiceUrl}/message`,
+        { user_id: userId, message },
+        { timeout: this.ragTimeoutMs },
+      );
+      return response.data;
+    } catch (error: any) {
+      this.logger.warn('RAG service request failed; continuing without RAG context', {
+        error: error?.message ?? String(error),
+      });
+      return null;
+    }
   }
 
   /**

--- a/tenant_portal_backend/test/chatbot-rag.e2e.spec.ts
+++ b/tenant_portal_backend/test/chatbot-rag.e2e.spec.ts
@@ -1,0 +1,118 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import request from 'supertest';
+import http, { IncomingMessage, ServerResponse } from 'http';
+import { AddressInfo } from 'net';
+import { AppModule } from '../src/app.module';
+import { PrismaService } from '../src/prisma/prisma.service';
+import { TestDataFactory } from './factories';
+import { Role } from '@prisma/client';
+import { resetDatabase } from './utils/reset-database';
+
+describe('Chatbot RAG API (e2e)', () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+  let tenantToken: string;
+  let ragServer: http.Server;
+  let ragServiceUrl: string;
+
+  beforeAll(async () => {
+    ragServer = http.createServer((req: IncomingMessage, res: ServerResponse) => {
+      if (req.method === 'GET' && req.url === '/health') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ status: 'ok' }));
+        return;
+      }
+
+      if (req.method === 'POST' && req.url === '/message') {
+        let body = '';
+        req.on('data', (chunk) => {
+          body += chunk;
+        });
+        req.on('end', () => {
+          const payload = JSON.parse(body || '{}');
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(
+            JSON.stringify({
+              session_id: `rag-${payload.user_id}`,
+              intent: 'rent_question',
+              workflow: 'rent_reminder',
+              response: { content: 'RAG: rent is due on the 1st. You can pay via the portal.' },
+              documents: ['Rent payment options'],
+              history_length: 2,
+            }),
+          );
+        });
+        return;
+      }
+
+      res.writeHead(404);
+      res.end();
+    });
+
+    await new Promise<void>((resolve) => {
+      ragServer.listen(0, '127.0.0.1', () => resolve());
+    });
+
+    ragServiceUrl = `http://127.0.0.1:${(ragServer.address() as AddressInfo).port}`;
+    process.env.AI_RAG_ENABLED = 'true';
+    process.env.AI_RAG_SERVICE_URL = ragServiceUrl;
+    process.env.AI_RAG_TIMEOUT_MS = '1500';
+    process.env.AI_ENABLED = 'false';
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe());
+    await app.init();
+
+    prisma = app.get<PrismaService>(PrismaService);
+  });
+
+  beforeEach(async () => {
+    await resetDatabase(prisma);
+
+    await prisma.user.create({
+      data: TestDataFactory.createUser({
+        username: 'tenant@test.com',
+        role: Role.TENANT,
+      }),
+    });
+
+    const tenantLogin = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ username: 'tenant@test.com', password: 'password123' });
+    tenantToken = tenantLogin.body.accessToken;
+  });
+
+  afterAll(async () => {
+    if (ragServer) {
+      ragServer.close();
+    }
+    await resetDatabase(prisma);
+    await app.close();
+  });
+
+  it('returns RAG-enriched responses and workflow metadata', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/chatbot/message')
+      .set('Authorization', `Bearer ${tenantToken}`)
+      .send({ message: 'I am late on rent, what should I do?' })
+      .expect(201);
+
+    expect(response.body.message).toContain('RAG: rent is due on the 1st');
+    expect(response.body.rag_workflow).toBe('rent_reminder');
+    expect(response.body.rag_documents).toContain('Rent payment options');
+    expect(response.body.rag_session_id).toContain('rag-');
+    expect(response.body.suggestedActions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: 'navigate',
+          params: { path: '/payments' },
+        }),
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- Expose the existing Python RAG pipeline as an HTTP service so the NestJS chatbot can request KB-driven context and draft responses.
- Surface RAG-derived `intent`/`workflow` signals and retrieved `documents` into the chatbot response payload for better routing and suggested actions.
- Make the RAG service container-ready with a health check so it can run as a sidecar and be monitored independently.
- Allow the OpenAI prompt to be optionally enriched with RAG context to improve final AI responses.

### Description
- Add a FastAPI wrapper at `tenant_portal_backend/chatbot/service.py` exposing `/health` and `/message` and returning `{ session_id, intent, workflow, response, documents }`.
- Add containerization and runtime files `tenant_portal_backend/chatbot/Dockerfile` and `tenant_portal_backend/chatbot/requirements.txt` and set `PYTHONPATH` to import the package inside the image.
- Extend `ChatbotService` (`tenant_portal_backend/src/chatbot/chatbot.service.ts`) with new config keys `AI_RAG_ENABLED`, `AI_RAG_SERVICE_URL`, and `AI_RAG_TIMEOUT_MS`, an internal `fetchRagResponse` call, `buildRagContext` injection into `generateAIResponse`, and extra response fields (`rag_session_id`, `rag_intent`, `rag_workflow`, `rag_documents`, `rag_response`) plus workflow-to-action mapping (`generateWorkflowActions`) and action merging (`mergeSuggestedActions`).
- Add an end-to-end test `tenant_portal_backend/test/chatbot-rag.e2e.spec.ts` that spins up a mock RAG HTTP server and verifies the NestJS `/chatbot/message` endpoint returns RAG-enriched content and workflow-driven suggested actions.

### Testing
- Added the e2e test file `tenant_portal_backend/test/chatbot-rag.e2e.spec.ts` to validate RAG enrichment and workflow propagation from the mock RAG server.
- No automated test suites (unit or e2e) were executed as part of this rollout, so no tests were run or reported in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c2bf3af34832aa9006eac448fec2d)