### PR TITLE
Add Prisma setup guidance and scripts for data quality runs

### DIFF
--- a/docs/implementation/clean_data_contracts.md
+++ b/docs/implementation/clean_data_contracts.md
@@ -1,0 +1,36 @@
+# Clean Data Contracts
+
+## clean_user View
+**Source**: `scripts/data-quality/build_clean_views.sql`
+
+### Contract
+- Required fields: `email`, `phone_number`, `first_name`, `last_name`
+- Validity checks:
+  - `is_email_valid` uses RFC-5322 regex
+  - `is_phone_valid` enforces E.164 format
+- Derived fields:
+  - `profile_completeness_score` (0-1) based on required identity fields
+
+### Notes
+- Records missing any required fields are excluded.
+- Use this view for downstream reporting and identity matching.
+
+---
+
+## clean_property View
+**Source**: `scripts/data-quality/build_clean_views.sql`
+
+### Contract
+- Required fields: `address`, `city`, `state`, `zip_code`
+- Validity checks:
+  - `is_rent_valid` ensures minRent <= maxRent
+  - `is_geo_valid` ensures latitude/longitude range
+  - `is_marketing_rent_valid` ensures profile min/max rent alignment
+- Derived fields:
+  - `rent_range`
+  - `has_rent_range`
+  - `profile_completeness_score` (0-1) based on address + geo fields
+
+### Notes
+- Records missing required fields are excluded.
+- The view includes marketing profile alignment for reporting.

--- a/docs/implementation/data_dictionary.md
+++ b/docs/implementation/data_dictionary.md
@@ -1,0 +1,40 @@
+# Data Dictionary (Quality Scope)
+
+## User
+| Field | Type | Description | Rules |
+| --- | --- | --- | --- |
+| email | String | Primary email address | Required for active tenants; RFC-5322 regex |
+| phoneNumber | String | Tenant phone number | Required for active tenants; E.164 format |
+| firstName | String | Tenant first name | Required for active tenants |
+| lastName | String | Tenant last name | Required for active tenants |
+
+## Property
+| Field | Type | Description | Rules |
+| --- | --- | --- | --- |
+| address | String | Street address | Required |
+| city | String | City | Required |
+| state | String | State code | Required; ISO-3166-2 US |
+| zipCode | String | Postal code | Required |
+| country | String | Country code | ISO-3166-1 alpha-2; default US |
+| latitude | Float | Latitude | Range [-90, 90] |
+| longitude | Float | Longitude | Range [-180, 180] |
+| minRent | Float | Minimum rent | Must be <= maxRent |
+| maxRent | Float | Maximum rent | Must be >= minRent |
+
+## PropertyMarketingProfile
+| Field | Type | Description | Rules |
+| --- | --- | --- | --- |
+| minRent | Float | Marketing min rent | Must be <= maxRent |
+| maxRent | Float | Marketing max rent | Must be >= minRent |
+| lastSyncedAt | DateTime | Syndication sync timestamp | Must meet SLA (24h) |
+
+## PropertyPhoto
+| Field | Type | Description | Rules |
+| --- | --- | --- | --- |
+| isPrimary | Boolean | Primary photo flag | Unique per property |
+
+## Amenity
+| Field | Type | Description | Rules |
+| --- | --- | --- | --- |
+| key | String | Amenity key | Normalized unique key |
+| label | String | Amenity label | Normalized unique label |

--- a/docs/implementation/data_quality_metrics.md
+++ b/docs/implementation/data_quality_metrics.md
@@ -1,0 +1,38 @@
+# Data Quality Metrics Tracking
+
+## Overview
+This document outlines the baseline metrics produced by the profiling scripts and how to refresh them weekly.
+
+## Source of Truth
+- SQL profiling script: `scripts/data-quality/profiling.sql`
+- Metrics table: `data_quality_metrics`
+
+## Metric Catalog
+| Metric Name | Entity | Definition | Notes |
+| --- | --- | --- | --- |
+| null_rate | User | Null ratio per required user fields | Details JSON stores field, total, nulls |
+| null_rate | Property | Null ratio per required property fields | Details JSON stores field, total, nulls |
+| geo_coverage | Property | Ratio of properties with latitude + longitude | Details JSON stores total, with_geo |
+| geo_out_of_range | Property | Count of properties outside valid lat/long ranges | Details JSON stores total |
+| invalid_rent_range | Property | Count where minRent > maxRent | Details JSON stores total |
+| duplicate_address_count | Property | Count of duplicated normalized addresses | Details JSON stores normalized address |
+| duplicate_email_count | User | Count of duplicated normalized emails | Details JSON stores email + count |
+
+## Refresh Cadence
+- Schedule the SQL script weekly using the existing scheduler or a cron job tied to the analytics database.
+- Store the script output in the `data_quality_metrics` table and export to CSV for dashboarding.
+
+## Weekly Export (Example)
+```sql
+COPY (
+  SELECT
+    metric_date,
+    entity,
+    metric_name,
+    metric_value,
+    details
+  FROM data_quality_metrics
+  WHERE metric_date >= now() - interval '7 days'
+  ORDER BY metric_date DESC
+) TO '/tmp/data_quality_metrics.csv' WITH CSV HEADER;
+```

--- a/docs/implementation/data_quality_prisma_process.md
+++ b/docs/implementation/data_quality_prisma_process.md
@@ -1,0 +1,33 @@
+# Prisma Process for Data Quality Workflows
+
+## Overview
+This data quality program relies on Prisma-managed tables (e.g., `User`, `Property`, `PropertyMarketingProfile`).
+To prevent runtime errors, ensure Prisma migrations are applied and the Prisma Client is generated before running
+any data-quality SQL or TypeScript jobs.
+
+## Recommended Execution Order
+1. **Apply Prisma migrations** (or schema deploy) to ensure core tables exist.
+2. **Generate Prisma Client** so TypeScript jobs can connect safely.
+3. **Run SQL setup scripts** to create data quality tables and views.
+4. **Run normalization backfill** to standardize existing data.
+5. **Run dedupe candidate scripts** to populate staging tables.
+6. **Run merge procedures** only after manual review.
+7. **Run enrichment jobs** when API credentials are configured.
+
+## Why Prisma Comes First
+- The SQL scripts and jobs expect Prisma tables to be present and in sync with the schema.
+- Prisma Client generation is required before running any TypeScript scripts that use `PrismaClient`.
+
+## Automation Scripts
+Use the scripts below to ensure Prisma setup is handled consistently before data-quality runs:
+- `scripts/data-quality/run_prisma_setup.sh`
+- `scripts/data-quality/run_prisma_setup.ps1`
+
+## Example End-to-End Flow (Unix)
+```bash
+scripts/data-quality/run_prisma_setup.sh
+psql "$DATABASE_URL" -f scripts/data-quality/profiling.sql
+node scripts/data-quality/backfill_normalization.ts
+psql "$DATABASE_URL" -f scripts/data-quality/dedupe_users.sql
+psql "$DATABASE_URL" -f scripts/data-quality/dedupe_properties.sql
+```

--- a/docs/implementation/data_quality_slos.md
+++ b/docs/implementation/data_quality_slos.md
@@ -1,0 +1,31 @@
+# Data Quality SLOs
+
+## Availability & Freshness
+| SLO | Target | Measurement |
+| --- | --- | --- |
+| Marketing profile sync freshness | 95% within 24h | `PropertyMarketingProfile.lastSyncedAt` |
+
+## Completeness
+| SLO | Target | Measurement |
+| --- | --- | --- |
+| Property address completeness | > 99% | Null rate of address/city/state/zip |
+| User identity completeness | > 99% | Null rate of email/phone/first/last name |
+
+## Validity
+| SLO | Target | Measurement |
+| --- | --- | --- |
+| Email validity | > 99% | Regex validation count |
+| Phone validity | > 99% | E.164 validation count |
+| Rent range correctness | 100% | minRent <= maxRent |
+| Geo validity | 100% | lat/long within range |
+
+## Uniqueness
+| SLO | Target | Measurement |
+| --- | --- | --- |
+| Duplicate properties | < 0.1% | Normalized address duplicates |
+| Duplicate users | < 0.1% | Email duplicates; phone+name fallback |
+
+## Monitoring & Alerting
+- Run `scripts/data-quality/profiling.sql` weekly.
+- Alert if any SLO threshold is breached for two consecutive runs.
+- Store incidents and remediation notes in the analytics runbook.

--- a/scripts/data-quality/backfill_normalization.ts
+++ b/scripts/data-quality/backfill_normalization.ts
@@ -1,0 +1,158 @@
+import { PrismaClient } from '../../tenant_portal_backend/node_modules/@prisma/client';
+import { normalizeEmail } from '../../tenant_portal_backend/src/utils/normalizeEmail';
+import { normalizePhone } from '../../tenant_portal_backend/src/utils/normalizePhone';
+
+const prisma = new PrismaClient();
+
+const normalizeAddressField = (value?: string | null): string | null => {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const normalizeState = (value?: string | null): string | null => {
+  const trimmed = normalizeAddressField(value);
+  return trimmed ? trimmed.toUpperCase() : null;
+};
+
+const normalizeCountry = (value?: string | null): string | null => {
+  const trimmed = normalizeAddressField(value);
+  return trimmed ? trimmed.toUpperCase() : null;
+};
+
+const runUserBackfill = async (): Promise<void> => {
+  let cursorId: string | null = null;
+
+  while (true) {
+    const users = await prisma.user.findMany({
+      take: 250,
+      ...(cursorId !== null
+        ? {
+            skip: 1,
+            cursor: { id: cursorId },
+          }
+        : {}),
+      orderBy: { id: 'asc' },
+      select: {
+        id: true,
+        email: true,
+        phoneNumber: true,
+      },
+    });
+
+    if (users.length === 0) {
+      break;
+    }
+
+    const updates = users
+      .map((user) => {
+        const normalizedEmail = normalizeEmail(user.email);
+        const normalizedPhone = normalizePhone(user.phoneNumber);
+
+        const shouldUpdate =
+          normalizedEmail !== user.email ||
+          normalizedPhone !== user.phoneNumber;
+
+        return shouldUpdate
+          ? prisma.user.update({
+              where: { id: user.id },
+              data: {
+                email: normalizedEmail,
+                phoneNumber: normalizedPhone,
+              },
+            })
+          : null;
+      })
+      .filter((update): update is ReturnType<typeof prisma.user.update> => update !== null);
+
+    if (updates.length > 0) {
+      await prisma.$transaction(updates);
+    }
+
+    cursorId = users[users.length - 1].id;
+  }
+};
+
+const runPropertyBackfill = async (): Promise<void> => {
+  let cursorId: number | null = null;
+
+  while (true) {
+    const properties = await prisma.property.findMany({
+      take: 250,
+      ...(cursorId !== null
+        ? {
+            skip: 1,
+            cursor: { id: cursorId },
+          }
+        : {}),
+      orderBy: { id: 'asc' },
+      select: {
+        id: true,
+        address: true,
+        city: true,
+        state: true,
+        zipCode: true,
+        country: true,
+      },
+    });
+
+    if (properties.length === 0) {
+      break;
+    }
+
+    const updates = properties
+      .map((property) => {
+        const normalizedAddress = normalizeAddressField(property.address);
+        const normalizedCity = normalizeAddressField(property.city);
+        const normalizedState = normalizeState(property.state);
+        const normalizedZip = normalizeAddressField(property.zipCode);
+        const normalizedCountry = normalizeCountry(property.country || 'US');
+
+        const shouldUpdate =
+          normalizedAddress !== property.address ||
+          normalizedCity !== property.city ||
+          normalizedState !== property.state ||
+          normalizedZip !== property.zipCode ||
+          normalizedCountry !== property.country;
+
+        return shouldUpdate
+          ? prisma.property.update({
+              where: { id: property.id },
+              data: {
+                address: normalizedAddress,
+                city: normalizedCity,
+                state: normalizedState,
+                zipCode: normalizedZip,
+                country: normalizedCountry,
+              },
+            })
+          : null;
+      })
+      .filter(
+        (update): update is ReturnType<typeof prisma.property.update> => update !== null,
+      );
+
+    if (updates.length > 0) {
+      await prisma.$transaction(updates);
+    }
+
+    cursorId = properties[properties.length - 1].id;
+  }
+};
+
+const run = async (): Promise<void> => {
+  await runUserBackfill();
+  await runPropertyBackfill();
+};
+
+run()
+  .catch((error) => {
+    console.error('Normalization backfill failed:', error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scripts/data-quality/build_clean_views.sql
+++ b/scripts/data-quality/build_clean_views.sql
@@ -1,0 +1,79 @@
+CREATE OR REPLACE VIEW clean_user AS
+SELECT
+  u.id,
+  u.username,
+  u.email,
+  u."phoneNumber" AS phone_number,
+  u."firstName" AS first_name,
+  u."lastName" AS last_name,
+  u.role,
+  u."lastLoginAt" AS last_login_at,
+  u."createdAt" AS created_at,
+  u."updatedAt" AS updated_at,
+  (u.email ~* '^(?:[a-z0-9!#$%&''*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&''*+/=?^_`{|}~-]+)*|"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])$') AS is_email_valid,
+  (u."phoneNumber" ~ '^\\+[1-9]\\d{7,14}$') AS is_phone_valid,
+  (
+    (CASE WHEN u.email IS NOT NULL THEN 1 ELSE 0 END +
+     CASE WHEN u."phoneNumber" IS NOT NULL THEN 1 ELSE 0 END +
+     CASE WHEN u."firstName" IS NOT NULL THEN 1 ELSE 0 END +
+     CASE WHEN u."lastName" IS NOT NULL THEN 1 ELSE 0 END
+    ) / 4.0
+  ) AS profile_completeness_score
+FROM "User" u
+WHERE u."firstName" IS NOT NULL
+  AND u."lastName" IS NOT NULL
+  AND u.email IS NOT NULL
+  AND u."phoneNumber" IS NOT NULL
+  AND u.email ~* '^(?:[a-z0-9!#$%&''*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&''*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])$'
+  AND u."phoneNumber" ~ '^\\+[1-9]\\d{7,14}$';
+
+CREATE OR REPLACE VIEW clean_property AS
+SELECT
+  p.id,
+  p.name,
+  p.address,
+  p.city,
+  p.state,
+  p."zipCode" AS zip_code,
+  COALESCE(p.country, 'US') AS country,
+  p.latitude,
+  p.longitude,
+  p."minRent" AS min_rent,
+  p."maxRent" AS max_rent,
+  p."propertyType" AS property_type,
+  p.bedrooms,
+  p.bathrooms,
+  p.tags,
+  p."yearBuilt" AS year_built,
+  p."createdAt" AS created_at,
+  p."updatedAt" AS updated_at,
+  mp."availabilityStatus" AS availability_status,
+  mp."lastSyncedAt" AS last_synced_at,
+  mp."minRent" AS marketing_min_rent,
+  mp."maxRent" AS marketing_max_rent,
+  (p."minRent" IS NULL OR p."maxRent" IS NULL OR p."minRent" <= p."maxRent") AS is_rent_valid,
+  (p.latitude BETWEEN -90 AND 90 AND p.longitude BETWEEN -180 AND 180) AS is_geo_valid,
+  (mp."minRent" IS NULL OR mp."maxRent" IS NULL OR mp."minRent" <= mp."maxRent") AS is_marketing_rent_valid,
+  (mp."minRent" IS NULL OR mp."maxRent" IS NULL OR p."minRent" IS NULL OR p."maxRent" IS NULL OR (p."minRent" = mp."minRent" AND p."maxRent" = mp."maxRent")) AS is_rent_consistent,
+  (p."minRent" IS NOT NULL AND p."maxRent" IS NOT NULL) AS has_rent_range,
+  (p."maxRent" - p."minRent") AS rent_range,
+  (
+    (CASE WHEN p.address IS NOT NULL THEN 1 ELSE 0 END +
+     CASE WHEN p.city IS NOT NULL THEN 1 ELSE 0 END +
+     CASE WHEN p.state IS NOT NULL THEN 1 ELSE 0 END +
+     CASE WHEN p."zipCode" IS NOT NULL THEN 1 ELSE 0 END +
+     CASE WHEN p.latitude IS NOT NULL THEN 1 ELSE 0 END +
+     CASE WHEN p.longitude IS NOT NULL THEN 1 ELSE 0 END
+    ) / 6.0
+  ) AS profile_completeness_score
+FROM "Property" p
+LEFT JOIN "PropertyMarketingProfile" mp
+  ON mp."propertyId" = p.id
+WHERE p.address IS NOT NULL
+  AND p.city IS NOT NULL
+  AND p.state IS NOT NULL
+  AND p."zipCode" IS NOT NULL
+  AND (p."minRent" IS NULL OR p."maxRent" IS NULL OR p."minRent" <= p."maxRent")
+  AND p.latitude BETWEEN -90 AND 90
+  AND p.longitude BETWEEN -180 AND 180
+  AND (mp."minRent" IS NULL OR mp."maxRent" IS NULL OR mp."minRent" <= mp."maxRent");

--- a/scripts/data-quality/dedupe_properties.sql
+++ b/scripts/data-quality/dedupe_properties.sql
@@ -1,0 +1,45 @@
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS data_quality_dedupe_candidates (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  candidate_type text NOT NULL,
+  primary_id text NOT NULL,
+  duplicate_id text NOT NULL,
+  match_rule text NOT NULL,
+  confidence numeric NOT NULL DEFAULT 1,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (candidate_type, primary_id, duplicate_id, match_rule)
+);
+
+WITH normalized_properties AS (
+  SELECT
+    id,
+    lower(trim(address)) AS address_norm,
+    lower(trim(city)) AS city_norm,
+    lower(trim(state)) AS state_norm,
+    trim("zipCode") AS zip_norm
+  FROM "Property"
+  WHERE address IS NOT NULL
+    AND city IS NOT NULL
+    AND state IS NOT NULL
+    AND "zipCode" IS NOT NULL
+),
+ranked AS (
+  SELECT
+    id,
+    address_norm,
+    city_norm,
+    state_norm,
+    zip_norm,
+    MIN(id) OVER (PARTITION BY address_norm, city_norm, state_norm, zip_norm) AS primary_id
+  FROM normalized_properties
+)
+INSERT INTO data_quality_dedupe_candidates (candidate_type, primary_id, duplicate_id, match_rule)
+SELECT
+  'Property' AS candidate_type,
+  primary_id,
+  id AS duplicate_id,
+  'address_exact' AS match_rule
+FROM ranked
+WHERE id <> primary_id
+ON CONFLICT DO NOTHING;

--- a/scripts/data-quality/dedupe_users.sql
+++ b/scripts/data-quality/dedupe_users.sql
@@ -1,0 +1,68 @@
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS data_quality_dedupe_candidates (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  candidate_type text NOT NULL,
+  primary_id text NOT NULL,
+  duplicate_id text NOT NULL,
+  match_rule text NOT NULL,
+  confidence numeric NOT NULL DEFAULT 1,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (candidate_type, primary_id, duplicate_id, match_rule)
+);
+
+-- Email-based duplicates
+WITH normalized_emails AS (
+  SELECT
+    id,
+    lower(trim(email)) AS email_norm
+  FROM "User"
+  WHERE email IS NOT NULL
+),
+ranked AS (
+  SELECT
+    id,
+    email_norm,
+    MIN(id) OVER (PARTITION BY email_norm) AS primary_id
+  FROM normalized_emails
+)
+INSERT INTO data_quality_dedupe_candidates (candidate_type, primary_id, duplicate_id, match_rule)
+SELECT
+  'User' AS candidate_type,
+  primary_id,
+  id AS duplicate_id,
+  'email_exact' AS match_rule
+FROM ranked
+WHERE id <> primary_id
+ON CONFLICT DO NOTHING;
+
+-- Phone + name duplicates (fallback)
+WITH normalized AS (
+  SELECT
+    id,
+    regexp_replace("phoneNumber", '\\D', '', 'g') AS phone_norm,
+    lower(trim("firstName")) AS first_name_norm,
+    lower(trim("lastName")) AS last_name_norm
+  FROM "User"
+  WHERE "phoneNumber" IS NOT NULL
+    AND "firstName" IS NOT NULL
+    AND "lastName" IS NOT NULL
+),
+ranked AS (
+  SELECT
+    id,
+    phone_norm,
+    first_name_norm,
+    last_name_norm,
+    MIN(id) OVER (PARTITION BY phone_norm, first_name_norm, last_name_norm) AS primary_id
+  FROM normalized
+)
+INSERT INTO data_quality_dedupe_candidates (candidate_type, primary_id, duplicate_id, match_rule)
+SELECT
+  'User' AS candidate_type,
+  primary_id,
+  id AS duplicate_id,
+  'phone_name' AS match_rule
+FROM ranked
+WHERE id <> primary_id
+ON CONFLICT DO NOTHING;

--- a/scripts/data-quality/merge_duplicates.sql
+++ b/scripts/data-quality/merge_duplicates.sql
@@ -1,0 +1,64 @@
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS data_quality_merge_audit (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  entity text NOT NULL,
+  primary_id text NOT NULL,
+  duplicate_id text NOT NULL,
+  merged_at timestamptz NOT NULL DEFAULT now(),
+  notes text
+);
+
+CREATE OR REPLACE PROCEDURE merge_user_duplicate(primary_user_id uuid, duplicate_user_id uuid)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  record_row record;
+BEGIN
+  FOR record_row IN
+    SELECT
+      conrelid::regclass AS table_name,
+      attname AS column_name
+    FROM pg_constraint
+    JOIN pg_attribute ON pg_attribute.attnum = ANY (pg_constraint.conkey)
+      AND pg_attribute.attrelid = pg_constraint.conrelid
+    WHERE confrelid = '"User"'::regclass
+      AND contype = 'f'
+  LOOP
+    EXECUTE format('UPDATE %s SET %I = $1 WHERE %I = $2', record_row.table_name, record_row.column_name, record_row.column_name)
+    USING primary_user_id, duplicate_user_id;
+  END LOOP;
+
+  DELETE FROM "User" WHERE id = duplicate_user_id;
+
+  INSERT INTO data_quality_merge_audit (entity, primary_id, duplicate_id, notes)
+  VALUES ('User', primary_user_id::text, duplicate_user_id::text, 'Merged via stored procedure');
+END;
+$$;
+
+CREATE OR REPLACE PROCEDURE merge_property_duplicate(primary_property_id integer, duplicate_property_id integer)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  record_row record;
+BEGIN
+  FOR record_row IN
+    SELECT
+      conrelid::regclass AS table_name,
+      attname AS column_name
+    FROM pg_constraint
+    JOIN pg_attribute ON pg_attribute.attnum = ANY (pg_constraint.conkey)
+      AND pg_attribute.attrelid = pg_constraint.conrelid
+    WHERE confrelid = '"Property"'::regclass
+      AND contype = 'f'
+  LOOP
+    EXECUTE format('UPDATE %s SET %I = $1 WHERE %I = $2', record_row.table_name, record_row.column_name, record_row.column_name)
+    USING primary_property_id, duplicate_property_id;
+  END LOOP;
+
+  DELETE FROM "Property" WHERE id = duplicate_property_id;
+
+  INSERT INTO data_quality_merge_audit (entity, primary_id, duplicate_id, notes)
+  VALUES ('Property', primary_property_id::text, duplicate_property_id::text, 'Merged via stored procedure');
+END;
+$$;

--- a/scripts/data-quality/profiling.sql
+++ b/scripts/data-quality/profiling.sql
@@ -1,0 +1,140 @@
+-- Data quality profiling metrics
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+-- Idempotent creation of the metrics table
+CREATE TABLE IF NOT EXISTS data_quality_metrics (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  metric_date timestamptz NOT NULL DEFAULT now(),
+  entity text NOT NULL,
+  metric_name text NOT NULL,
+  metric_value numeric NOT NULL,
+  details jsonb DEFAULT '{}'::jsonb
+);
+
+-- Null rates for key user fields
+INSERT INTO data_quality_metrics (entity, metric_name, metric_value, details)
+SELECT
+  'User' AS entity,
+  'null_rate' AS metric_name,
+  CASE WHEN COUNT(*) = 0 THEN 0 ELSE SUM((email IS NULL)::int)::numeric / COUNT(*) END AS metric_value,
+  jsonb_build_object('field', 'email', 'total', COUNT(*), 'nulls', SUM((email IS NULL)::int))
+FROM "User";
+
+INSERT INTO data_quality_metrics (entity, metric_name, metric_value, details)
+SELECT
+  'User' AS entity,
+  'null_rate' AS metric_name,
+  CASE WHEN COUNT(*) = 0 THEN 0 ELSE SUM(("phoneNumber" IS NULL)::int)::numeric / COUNT(*) END AS metric_value,
+  jsonb_build_object('field', 'phoneNumber', 'total', COUNT(*), 'nulls', SUM(("phoneNumber" IS NULL)::int))
+FROM "User";
+
+INSERT INTO data_quality_metrics (entity, metric_name, metric_value, details)
+SELECT
+  'User' AS entity,
+  'null_rate' AS metric_name,
+  CASE WHEN COUNT(*) = 0 THEN 0 ELSE SUM(("firstName" IS NULL)::int)::numeric / COUNT(*) END AS metric_value,
+  jsonb_build_object('field', 'firstName', 'total', COUNT(*), 'nulls', SUM(("firstName" IS NULL)::int))
+FROM "User";
+
+INSERT INTO data_quality_metrics (entity, metric_name, metric_value, details)
+SELECT
+  'User' AS entity,
+  'null_rate' AS metric_name,
+  CASE WHEN COUNT(*) = 0 THEN 0 ELSE SUM(("lastName" IS NULL)::int)::numeric / COUNT(*) END AS metric_value,
+  jsonb_build_object('field', 'lastName', 'total', COUNT(*), 'nulls', SUM(("lastName" IS NULL)::int))
+FROM "User";
+
+-- Null rates for key property fields
+INSERT INTO data_quality_metrics (entity, metric_name, metric_value, details)
+SELECT
+  'Property' AS entity,
+  'null_rate' AS metric_name,
+  CASE WHEN COUNT(*) = 0 THEN 0 ELSE SUM((address IS NULL)::int)::numeric / COUNT(*) END AS metric_value,
+  jsonb_build_object('field', 'address', 'total', COUNT(*), 'nulls', SUM((address IS NULL)::int))
+FROM "Property";
+
+INSERT INTO data_quality_metrics (entity, metric_name, metric_value, details)
+SELECT
+  'Property' AS entity,
+  'null_rate' AS metric_name,
+  CASE WHEN COUNT(*) = 0 THEN 0 ELSE SUM((city IS NULL)::int)::numeric / COUNT(*) END AS metric_value,
+  jsonb_build_object('field', 'city', 'total', COUNT(*), 'nulls', SUM((city IS NULL)::int))
+FROM "Property";
+
+INSERT INTO data_quality_metrics (entity, metric_name, metric_value, details)
+SELECT
+  'Property' AS entity,
+  'null_rate' AS metric_name,
+  CASE WHEN COUNT(*) = 0 THEN 0 ELSE SUM((state IS NULL)::int)::numeric / COUNT(*) END AS metric_value,
+  jsonb_build_object('field', 'state', 'total', COUNT(*), 'nulls', SUM((state IS NULL)::int))
+FROM "Property";
+
+INSERT INTO data_quality_metrics (entity, metric_name, metric_value, details)
+SELECT
+  'Property' AS entity,
+  'null_rate' AS metric_name,
+  CASE WHEN COUNT(*) = 0 THEN 0 ELSE SUM(("zipCode" IS NULL)::int)::numeric / COUNT(*) END AS metric_value,
+  jsonb_build_object('field', 'zipCode', 'total', COUNT(*), 'nulls', SUM(("zipCode" IS NULL)::int))
+FROM "Property";
+
+-- Latitude/longitude coverage
+INSERT INTO data_quality_metrics (entity, metric_name, metric_value, details)
+SELECT
+  'Property' AS entity,
+  'geo_coverage' AS metric_name,
+  CASE WHEN COUNT(*) = 0 THEN 0 ELSE SUM((latitude IS NOT NULL AND longitude IS NOT NULL)::int)::numeric / COUNT(*) END AS metric_value,
+  jsonb_build_object('total', COUNT(*), 'with_geo', SUM((latitude IS NOT NULL AND longitude IS NOT NULL)::int))
+FROM "Property";
+
+-- Out-of-range coordinates
+INSERT INTO data_quality_metrics (entity, metric_name, metric_value, details)
+SELECT
+  'Property' AS entity,
+  'geo_out_of_range' AS metric_name,
+  SUM((latitude < -90 OR latitude > 90 OR longitude < -180 OR longitude > 180)::int),
+  jsonb_build_object('total', COUNT(*))
+FROM "Property";
+
+-- Invalid rent ranges
+INSERT INTO data_quality_metrics (entity, metric_name, metric_value, details)
+SELECT
+  'Property' AS entity,
+  'invalid_rent_range' AS metric_name,
+  SUM(("minRent" IS NOT NULL AND "maxRent" IS NOT NULL AND "minRent" > "maxRent")::int),
+  jsonb_build_object('total', COUNT(*))
+FROM "Property";
+
+-- Duplicate properties by normalized address
+INSERT INTO data_quality_metrics (entity, metric_name, metric_value, details)
+SELECT
+  'Property' AS entity,
+  'duplicate_address_count' AS metric_name,
+  COUNT(*)::numeric,
+  jsonb_build_object('address_norm', address_norm, 'city_norm', city_norm, 'state_norm', state_norm, 'zip_norm', zip_norm)
+FROM (
+  SELECT
+    lower(trim(address)) AS address_norm,
+    lower(trim(city)) AS city_norm,
+    lower(trim(state)) AS state_norm,
+    trim("zipCode") AS zip_norm,
+    COUNT(*) AS dup_count
+  FROM "Property"
+  GROUP BY 1, 2, 3, 4
+  HAVING COUNT(*) > 1
+) duplicates;
+
+-- Duplicate users by email
+INSERT INTO data_quality_metrics (entity, metric_name, metric_value, details)
+SELECT
+  'User' AS entity,
+  'duplicate_email_count' AS metric_name,
+  COUNT(*)::numeric,
+  jsonb_build_object('email', email_norm, 'dup_count', dup_count)
+FROM (
+  SELECT
+    lower(trim(email)) AS email_norm,
+    COUNT(*) AS dup_count
+  FROM "User"
+  WHERE email IS NOT NULL
+  GROUP BY 1
+  HAVING COUNT(*) > 1
+) duplicates;

--- a/scripts/data-quality/run_prisma_setup.ps1
+++ b/scripts/data-quality/run_prisma_setup.ps1
@@ -1,0 +1,20 @@
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot = Resolve-Path (Join-Path $ScriptDir "..\..")
+$BackendDir = Join-Path $RepoRoot "tenant_portal_backend"
+
+if (-not $env:DATABASE_URL) {
+  Write-Error "DATABASE_URL is not set. Prisma commands require a valid database connection."
+  exit 1
+}
+
+Set-Location $BackendDir
+
+Write-Host "Running Prisma migrations (deploy)..."
+./node_modules/.bin/prisma migrate deploy
+
+Write-Host "Generating Prisma Client..."
+./node_modules/.bin/prisma generate
+
+Write-Host "Prisma setup complete."

--- a/scripts/data-quality/run_prisma_setup.sh
+++ b/scripts/data-quality/run_prisma_setup.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+BACKEND_DIR="${REPO_ROOT}/tenant_portal_backend"
+
+cd "${BACKEND_DIR}"
+
+if [[ -z "${DATABASE_URL:-}" ]]; then
+  echo "DATABASE_URL is not set. Prisma commands require a valid database connection." >&2
+  exit 1
+fi
+
+echo "Running Prisma migrations (deploy)..."
+./node_modules/.bin/prisma migrate deploy
+
+echo "Generating Prisma Client..."
+./node_modules/.bin/prisma generate
+
+echo "Prisma setup complete."

--- a/scripts/enrichment/geocode_properties.ts
+++ b/scripts/enrichment/geocode_properties.ts
@@ -1,0 +1,151 @@
+import { Prisma, PrismaClient } from '../../tenant_portal_backend/node_modules/@prisma/client';
+
+const prisma = new PrismaClient();
+
+const geocodingApiUrl = process.env.GEOCODING_API_URL;
+const geocodingApiKey = process.env.GEOCODING_API_KEY;
+const geocodingSource = process.env.GEOCODING_SOURCE || 'external-geocoder';
+
+type GeocodeResult = {
+  latitude: number;
+  longitude: number;
+  confidence?: number;
+  raw: unknown;
+};
+
+const ensureMetadataTable = async (): Promise<void> => {
+  await prisma.$executeRaw(
+    Prisma.sql`
+      CREATE TABLE IF NOT EXISTS property_enrichment_metadata (
+        property_id integer PRIMARY KEY,
+        source text NOT NULL,
+        confidence numeric,
+        updated_at timestamptz NOT NULL DEFAULT now(),
+        payload jsonb NOT NULL
+      );
+    `,
+  );
+};
+
+const buildGeocodingUrl = (address: string): string => {
+  if (!geocodingApiUrl) {
+    throw new Error('GEOCODING_API_URL must be set for geocoding enrichment.');
+  }
+
+  if (geocodingApiUrl.includes('{{query}}')) {
+    return geocodingApiUrl.replace('{{query}}', encodeURIComponent(address));
+  }
+
+  const connector = geocodingApiUrl.includes('?') ? '&' : '?';
+  return `${geocodingApiUrl}${connector}q=${encodeURIComponent(address)}&format=json&limit=1`;
+};
+
+const parseGeocodeResponse = (payload: any): GeocodeResult | null => {
+  if (!payload) {
+    return null;
+  }
+
+  const result = Array.isArray(payload)
+    ? payload[0]
+    : payload.results?.[0] ?? payload;
+
+  if (!result) {
+    return null;
+  }
+
+  const latitude = Number(result.lat ?? result.latitude ?? result.geometry?.location?.lat);
+  const longitude = Number(result.lon ?? result.lng ?? result.longitude ?? result.geometry?.location?.lng);
+
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+    return null;
+  }
+
+  return {
+    latitude,
+    longitude,
+    confidence: Number(result.confidence ?? result.score ?? result.importance ?? 0) || undefined,
+    raw: payload,
+  };
+};
+
+const fetchGeocode = async (address: string): Promise<GeocodeResult | null> => {
+  const url = buildGeocodingUrl(address);
+  const response = await fetch(url, {
+    headers: geocodingApiKey ? { Authorization: `Bearer ${geocodingApiKey}` } : undefined,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Geocoding request failed: ${response.status} ${response.statusText}`);
+  }
+
+  const payload = await response.json();
+  return parseGeocodeResponse(payload);
+};
+
+const run = async (): Promise<void> => {
+  await ensureMetadataTable();
+
+  const properties = await prisma.property.findMany({
+    where: {
+      OR: [{ latitude: null }, { longitude: null }],
+      address: { not: null },
+      city: { not: null },
+      state: { not: null },
+      zipCode: { not: null },
+    },
+    select: {
+      id: true,
+      address: true,
+      city: true,
+      state: true,
+      zipCode: true,
+    },
+  });
+
+  for (const property of properties) {
+    const address = `${property.address}, ${property.city}, ${property.state} ${property.zipCode}`;
+    const geocode = await fetchGeocode(address);
+
+    if (!geocode) {
+      continue;
+    }
+
+    await prisma.$transaction([
+      prisma.property.update({
+        where: { id: property.id },
+        data: {
+          latitude: geocode.latitude,
+          longitude: geocode.longitude,
+        },
+      }),
+      prisma.$executeRaw(
+        Prisma.sql`
+          INSERT INTO property_enrichment_metadata (property_id, source, confidence, updated_at, payload)
+          VALUES (
+            ${property.id},
+            ${geocodingSource},
+            ${geocode.confidence ?? null},
+            now(),
+            ${JSON.stringify(geocode.raw)}
+          )
+          ON CONFLICT (property_id) DO UPDATE SET
+            source = EXCLUDED.source,
+            confidence = EXCLUDED.confidence,
+            updated_at = EXCLUDED.updated_at,
+            payload = EXCLUDED.payload;
+        `,
+      ),
+    ]);
+
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+};
+
+run()
+  .catch((error) => {
+    console.error('Geocoding enrichment failed:', error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/tenant_portal_backend/src/utils/normalizeEmail.ts
+++ b/tenant_portal_backend/src/utils/normalizeEmail.ts
@@ -1,0 +1,19 @@
+const RFC5322_EMAIL_REGEX = /^(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])$/i;
+
+export const normalizeEmail = (email?: string | null): string | null => {
+  if (!email) {
+    return null;
+  }
+
+  const trimmed = email.trim().toLowerCase();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+export const isValidEmail = (email?: string | null): boolean => {
+  const normalized = normalizeEmail(email);
+  if (!normalized) {
+    return false;
+  }
+
+  return RFC5322_EMAIL_REGEX.test(normalized);
+};

--- a/tenant_portal_backend/src/utils/normalizePhone.ts
+++ b/tenant_portal_backend/src/utils/normalizePhone.ts
@@ -1,0 +1,46 @@
+const E164_REGEX = /^\+[1-9]\d{7,14}$/;
+
+const stripToDigits = (value: string): string => value.replace(/\D/g, '');
+
+export const normalizePhone = (
+  phone?: string | null,
+  defaultCountryCode = '1',
+): string | null => {
+  if (!phone) {
+    return null;
+  }
+
+  const trimmed = phone.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (trimmed.startsWith('+')) {
+    const normalized = `+${stripToDigits(trimmed)}`;
+    return E164_REGEX.test(normalized) ? normalized : null;
+  }
+
+  const digits = stripToDigits(trimmed);
+  if (!digits) {
+    return null;
+  }
+
+  if (digits.length === 10) {
+    return `+${defaultCountryCode}${digits}`;
+  }
+
+  if (digits.length > 10 && digits.length <= 15) {
+    return `+${digits}`;
+  }
+
+  return null;
+};
+
+export const isValidE164Phone = (phone?: string | null): boolean => {
+  const normalized = normalizePhone(phone);
+  if (!normalized) {
+    return false;
+  }
+
+  return E164_REGEX.test(normalized);
+};


### PR DESCRIPTION
### Motivation
- Data-quality SQL and TypeScript jobs rely on Prisma-managed tables and a generated `PrismaClient`, so migrations and client generation must run first to avoid runtime errors.
- Provide a reproducible, cross-platform way to perform the required Prisma steps before running normalization, dedupe, merge, or enrichment jobs.
- Make the recommended execution order explicit to reduce operator errors when backfilling historical data and running enrichment jobs.

### Description
- Add `docs/implementation/data_quality_prisma_process.md` which documents the recommended execution order, rationale, automation scripts, and an example end-to-end flow using `scripts/data-quality/run_prisma_setup.sh`.
- Add an executable bash script `scripts/data-quality/run_prisma_setup.sh` that runs `prisma migrate deploy` and `prisma generate` and fails if `DATABASE_URL` is not set. 
- Add a PowerShell equivalent `scripts/data-quality/run_prisma_setup.ps1` for Windows users that performs the same checks and Prisma commands.
- Commit the new documentation and scripts so they can be used as the first step in the existing data-quality workflows (normalization, profiling, dedupe, merge, enrichment).

### Testing
- No automated tests were executed for these documentation and utility script changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950b69d9094832a98c8e6546e0e8317)