### PR TITLE
fix: resolve system and product gaps from audit

### DIFF
--- a/tenant_portal_backend/src/app.module.ts
+++ b/tenant_portal_backend/src/app.module.ts
@@ -44,6 +44,7 @@ import { MilModule } from './mil/mil.module';
 import { LegacyPathMiddleware } from './middleware/legacy-path.middleware';
 import { PerformanceMiddleware } from './monitoring/performance.middleware';
 import { CorrelationMiddleware } from './middleware/request-context/correlation.middleware';
+import { DevMockAuthMiddleware } from './middleware/dev-mock-auth.middleware';
 import { EventsModule } from './events/events.module'; // ADDED
 import { Web3Module } from './web3/web3.module';
 import { PrivacyModule } from './privacy/privacy.module';
@@ -179,6 +180,11 @@ const rateLimitProviders = rateLimitEnabled
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
+    // DevMockAuthMiddleware must run first so the JWT guard sees the injected token
+    consumer
+      .apply(DevMockAuthMiddleware)
+      .forRoutes('*');
+
     consumer
       .apply(CorrelationMiddleware)
       .forRoutes('*');
@@ -186,7 +192,7 @@ export class AppModule implements NestModule {
     consumer
       .apply(LegacyPathMiddleware)
       .forRoutes('*');
-    
+
     consumer
       .apply(PerformanceMiddleware)
       .forRoutes('*');

--- a/tenant_portal_backend/src/auth/auth.service.spec.ts
+++ b/tenant_portal_backend/src/auth/auth.service.spec.ts
@@ -7,6 +7,7 @@ import { SecurityEventsService } from '../security-events/security-events.servic
 import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '../prisma/prisma.service';
 import { EmailService } from '../email/email.service';
+import { TokenBlacklistService } from './revocation/token-blacklist.service';
 import { UnauthorizedException, BadRequestException } from '@nestjs/common';
 import * as bcrypt from 'bcrypt';
 import { authenticator } from 'otplib';
@@ -92,6 +93,11 @@ describe('AuthService', () => {
     milValidateSessionV1AuthSessionValidatePost: jest.fn(),
   };
 
+  const mockTokenBlacklist = {
+    blacklist: jest.fn(),
+    isBlacklisted: jest.fn().mockResolvedValue(false),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -104,6 +110,7 @@ describe('AuthService', () => {
         { provide: PrismaService, useValue: mockPrismaService },
         { provide: EmailService, useValue: mockEmailService },
         { provide: MilApiClient, useValue: mockMilApiClient },
+        { provide: TokenBlacklistService, useValue: mockTokenBlacklist },
       ],
     }).compile();
 
@@ -153,11 +160,13 @@ describe('AuthService', () => {
       expect(result).toEqual({ access_token: 'jwt-token', accessToken: 'jwt-token' });
       expect(mockUsersService.findOne).toHaveBeenCalledWith(loginDto.username);
       expect(bcryptMock.compare).toHaveBeenCalledWith(loginDto.password, mockUser.password);
-      expect(mockJwtService.sign).toHaveBeenCalledWith({
-        username: mockUser.username,
-        sub: mockUser.id,
-        role: mockUser.role,
-      });
+      expect(mockJwtService.sign).toHaveBeenCalledWith(
+        expect.objectContaining({
+          username: mockUser.username,
+          sub: mockUser.id,
+          role: mockUser.role,
+        }),
+      );
       expect(mockUsersService.update).toHaveBeenCalledWith(
         mockUser.id,
         expect.objectContaining({

--- a/tenant_portal_backend/src/common/org-context/org-context.guard.ts
+++ b/tenant_portal_backend/src/common/org-context/org-context.guard.ts
@@ -36,6 +36,11 @@ export class OrgContextGuard implements CanActivate {
     });
 
     if (memberships.length === 0) {
+      // In development, allow mock users through without org context.
+      // Controllers that require orgId will receive undefined and should handle it gracefully.
+      if (process.env.NODE_ENV !== 'production') {
+        return true;
+      }
       throw ApiException.forbidden(
         ErrorCode.AUTH_FORBIDDEN,
         'User is not a member of any organization',

--- a/tenant_portal_backend/src/middleware/dev-mock-auth.middleware.ts
+++ b/tenant_portal_backend/src/middleware/dev-mock-auth.middleware.ts
@@ -1,0 +1,85 @@
+/**
+ * DevMockAuthMiddleware
+ *
+ * Development-only middleware that converts X-Mock-User-Id / X-Mock-Role
+ * headers (sent by keyring-os admin in dev) into a signed JWT so that the
+ * standard AuthGuard('jwt') accepts the request without modification.
+ *
+ * NEVER active in production — guarded by NODE_ENV check.
+ */
+import { Injectable, NestMiddleware, Logger } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { ConfigService } from '@nestjs/config';
+import { createHmac } from 'crypto';
+
+// Role mapping: keyring-os sends lowercase 'admin', backend expects 'ADMIN'
+const ROLE_MAP: Record<string, string> = {
+  admin: 'ADMIN',
+  property_manager: 'PROPERTY_MANAGER',
+  pm: 'PROPERTY_MANAGER',
+  owner: 'OWNER',
+  tenant: 'TENANT',
+  operator: 'OPERATOR',
+};
+
+function base64url(input: string | Buffer): string {
+  const buf = typeof input === 'string' ? Buffer.from(input) : input;
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+function signJwt(payload: Record<string, unknown>, secret: string): string {
+  const header = base64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const body = base64url(JSON.stringify(payload));
+  const sig = base64url(
+    createHmac('sha256', secret)
+      .update(`${header}.${body}`)
+      .digest(),
+  );
+  return `${header}.${body}.${sig}`;
+}
+
+@Injectable()
+export class DevMockAuthMiddleware implements NestMiddleware {
+  private readonly logger = new Logger(DevMockAuthMiddleware.name);
+  private readonly isEnabled: boolean;
+
+  constructor(private readonly configService: ConfigService) {
+    const env = (configService.get<string>('NODE_ENV') ?? 'development').toLowerCase();
+    this.isEnabled = env !== 'production';
+    if (this.isEnabled) {
+      this.logger.warn(
+        'DevMockAuthMiddleware active — X-Mock-User-Id/X-Mock-Role headers accepted. Disable in production.',
+      );
+    }
+  }
+
+  use(req: Request, _res: Response, next: NextFunction) {
+    if (!this.isEnabled) return next();
+
+    const mockUserId = req.headers['x-mock-user-id'] as string | undefined;
+    const mockRole = req.headers['x-mock-role'] as string | undefined;
+
+    // Only inject if mock headers are present AND no real Authorization header exists
+    if (mockUserId && mockRole && !req.headers['authorization']) {
+      const normalizedRole = ROLE_MAP[mockRole.toLowerCase()] ?? mockRole.toUpperCase();
+      const secret = this.configService.get<string>('JWT_SECRET') ?? 'dev-jwt-secret-change-me';
+      const now = Math.floor(Date.now() / 1000);
+
+      const token = signJwt(
+        {
+          sub: mockUserId,
+          username: 'dev-mock-user',
+          role: normalizedRole,
+          iat: now,
+          exp: now + 3600,
+        },
+        secret,
+      );
+
+      req.headers['authorization'] = `Bearer ${token}`;
+      this.logger.debug(`Mock auth injected for userId=${mockUserId} role=${normalizedRole}`);
+    }
+
+    next();
+  }
+}

--- a/tenant_portal_backend/src/rental-application/rental-application.controller.ts
+++ b/tenant_portal_backend/src/rental-application/rental-application.controller.ts
@@ -156,6 +156,13 @@ export class RentalApplicationController {
     return this.rentalApplicationService.convertApprovedApplicationToLease(Number(id), req.user, body, orgId);
   }
 
+  @Get(':id/policy-evaluation')
+  @UseGuards(AuthGuard('jwt'), RolesGuard, OrgContextGuard)
+  @Roles('PROPERTY_MANAGER', 'ADMIN')
+  async getPolicyEvaluation(@Param('id') id: string, @OrgId() orgId?: string) {
+    return this.rentalApplicationService.getPolicyEvaluation(Number(id), orgId);
+  }
+
   @Post(':id/ai-review')
   @HttpCode(200)
   @UseGuards(AuthGuard('jwt'), RolesGuard, OrgContextGuard)

--- a/tenant_portal_backend/src/rental-application/rental-application.convert.spec.ts
+++ b/tenant_portal_backend/src/rental-application/rental-application.convert.spec.ts
@@ -1,6 +1,7 @@
 import { BadRequestException } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { ApplicationStatus, Role } from '@prisma/client';
+import { getQueueToken } from '@nestjs/bullmq';
 import { PrismaService } from '../prisma/prisma.service';
 import { SecurityEventsService } from '../security-events/security-events.service';
 import { AuditLogService } from '../shared/audit-log.service';
@@ -41,6 +42,7 @@ describe('RentalApplicationService convertApprovedApplicationToLease', () => {
         { provide: AuditLogService, useValue: { record: jest.fn() } },
         { provide: ScheduleService, useValue: scheduleService },
         { provide: NotificationsService, useValue: notificationsService },
+        { provide: getQueueToken('ai-screening'), useValue: { add: jest.fn() } },
       ],
     }).compile();
 

--- a/tenant_portal_backend/src/rental-application/rental-application.review-actions.spec.ts
+++ b/tenant_portal_backend/src/rental-application/rental-application.review-actions.spec.ts
@@ -1,6 +1,7 @@
 import { BadRequestException } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { ApplicationDecisionReasonCode, ApplicationStatus, Role } from '@prisma/client';
+import { getQueueToken } from '@nestjs/bullmq';
 import { PrismaService } from '../prisma/prisma.service';
 import { SecurityEventsService } from '../security-events/security-events.service';
 import { AuditLogService } from '../shared/audit-log.service';
@@ -48,6 +49,7 @@ describe('RentalApplicationService review actions', () => {
         { provide: AuditLogService, useValue: { record: jest.fn() } },
         { provide: ScheduleService, useValue: scheduleService },
         { provide: NotificationsService, useValue: { create: jest.fn() } },
+        { provide: getQueueToken('ai-screening'), useValue: { add: jest.fn() } },
       ],
     }).compile();
 

--- a/tenant_portal_backend/src/rental-application/rental-application.service.ts
+++ b/tenant_portal_backend/src/rental-application/rental-application.service.ts
@@ -1072,6 +1072,85 @@ export class RentalApplicationService {
     return createdLease;
   }
 
+  /**
+   * Returns a structured policy evaluation for the keyring-os screening workspace.
+   * Maps the existing calculateScreening logic to the PolicyEvaluation contract.
+   */
+  async getPolicyEvaluation(id: number, orgId?: string) {
+    const application = await this.prisma.rentalApplication.findFirst({
+      where: { id, ...(orgId ? { property: { organizationId: orgId } } : {}) },
+      include: { unit: { include: { lease: true } } },
+    });
+
+    if (!application) {
+      throw new Error('Rental application not found');
+    }
+
+    const rentAmount = Number(application.unit?.lease?.rentAmount ?? 0);
+    const income = Number(application.income ?? 0);
+    const creditScore = application.creditScore ?? null;
+    const incomeRatio = rentAmount > 0 ? income / rentAmount : 0;
+
+    const creditPassed = creditScore !== null ? creditScore >= 620 : false;
+    const incomePassed = incomeRatio >= 4;
+    // Eviction history: use screeningReasons as a proxy (no dedicated field).
+    // screeningReasons is a Prisma JsonValue so we cast to string[] safely.
+    const reasons = Array.isArray(application.screeningReasons)
+      ? (application.screeningReasons as string[])
+      : [];
+    const evictionPassed = !reasons.some((r) =>
+      typeof r === 'string' && r.toLowerCase().includes('eviction'),
+    );
+
+    const failCount = [creditPassed, incomePassed, evictionPassed].filter((p) => !p).length;
+    const verdict: 'approve' | 'conditional' | 'deny' =
+      failCount === 0 ? 'approve' : failCount === 1 ? 'conditional' : 'deny';
+
+    const requiredDeposit = verdict === 'conditional' ? Math.round(rentAmount * 1.5) : rentAmount;
+    const requiresCosigner = verdict === 'conditional' && !incomePassed;
+
+    return {
+      applicationId: String(id),
+      verdict,
+      criteria: [
+        {
+          rule: 'credit_score',
+          passed: creditPassed,
+          actual: creditScore !== null ? String(creditScore) : 'Not provided',
+          threshold: '620',
+          explanation: creditScore !== null
+            ? creditScore >= 620
+              ? `Credit score ${creditScore} meets minimum threshold of 620.`
+              : `Credit score ${creditScore} is below the minimum threshold of 620.`
+            : 'No credit score on file. Manual review required.',
+        },
+        {
+          rule: 'eviction_history',
+          passed: evictionPassed,
+          actual: evictionPassed ? 'None found' : 'Eviction on record',
+          threshold: 'No recent evictions',
+          explanation: evictionPassed
+            ? 'No eviction history detected in screening data.'
+            : 'Eviction history detected. Policy requires no evictions within 7 years.',
+        },
+        {
+          rule: 'income_ratio',
+          passed: incomePassed,
+          actual: `${incomeRatio.toFixed(2)}x`,
+          threshold: '4x',
+          explanation: incomePassed
+            ? `Monthly income $${income.toLocaleString()} is ${incomeRatio.toFixed(2)}x the rent of $${rentAmount.toLocaleString()}.`
+            : `Monthly income $${income.toLocaleString()} is only ${incomeRatio.toFixed(2)}x the rent of $${rentAmount.toLocaleString()}. Minimum is 4x.`,
+        },
+      ],
+      conditionalTerms: verdict === 'conditional'
+        ? { requiredDeposit, requiresCosigner }
+        : undefined,
+      overrideAllowed: true,
+      confidence: creditScore !== null ? 0.9 : 0.7,
+    };
+  }
+
   async getAiReview(applicationId: number, orgId?: string) {
     const application = await this.getApplicationById(applicationId, orgId);
     if (!application) {

--- a/tenant_portal_backend/src/rental-application/rental-application.submit.spec.ts
+++ b/tenant_portal_backend/src/rental-application/rental-application.submit.spec.ts
@@ -1,10 +1,12 @@
 import { BadRequestException } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { Role } from '@prisma/client';
+import { getQueueToken } from '@nestjs/bullmq';
 import { PrismaService } from '../prisma/prisma.service';
 import { SecurityEventsService } from '../security-events/security-events.service';
 import { AuditLogService } from '../shared/audit-log.service';
 import { ScheduleService } from '../schedule/schedule.service';
+import { NotificationsService } from '../notifications/notifications.service';
 import { ApplicationLifecycleService } from './application-lifecycle.service';
 import { RentalApplicationAiService } from './rental-application.ai.service';
 import { RentalApplicationService } from './rental-application.service';
@@ -35,6 +37,8 @@ describe('RentalApplicationService submitApplication hardening', () => {
         { provide: RentalApplicationAiService, useValue: {} },
         { provide: AuditLogService, useValue: { record: jest.fn() } },
         { provide: ScheduleService, useValue: {} },
+        { provide: NotificationsService, useValue: { sendNotification: jest.fn() } },
+        { provide: getQueueToken('ai-screening'), useValue: { add: jest.fn() } },
       ],
     }).compile();
 


### PR DESCRIPTION
## Summary

Full-stack product and system audit of pms-master + keyring-os. This PR fixes the issues that were preventing the system from functioning as a product — broken tests, a missing API endpoint, and a fundamental auth mismatch between the two frontends and the backend.

---

## What Was Broken

### 1. All keyring-os workspace pages showed empty data (silent 401s)

`keyring-os/apps/admin` sends `X-Mock-User-Id` and `X-Mock-Role` headers instead of a JWT. Every backend endpoint uses `AuthGuard('jwt')`, which rejected these requests with 401. The briefing page has a fallback that also calls JWT-protected endpoints, so it silently rendered "No critical signals. Operations normal." regardless of actual data. No decisions, signals, or events ever appeared in any workspace.

**Fix:** Added `DevMockAuthMiddleware` — runs first in the middleware chain, detects mock headers, signs a valid HS256 JWT using the configured `JWT_SECRET`, and injects it as `Authorization: Bearer`. Disabled in production via `NODE_ENV` check.

### 2. Screening detail panel was always empty (missing endpoint — 404)

`keyring-os/apps/admin/src/lib/copilot-api.ts` calls `GET /rental-applications/:id/policy-evaluation` on every applicant selection to render the verdict panel (Approve / Conditional / Deny, criteria breakdown, conditional terms). This endpoint did not exist. Every click produced a 404 and the panel showed nothing.

**Fix:** Added `GET /rental-applications/:id/policy-evaluation` to the controller and a `getPolicyEvaluation` service method. It reads the application, evaluates credit score (≥620), income ratio (≥4x rent), and eviction history, then returns a `PolicyEvaluation` object matching the `@keyring/types` contract.

### 3. Mock users got 403 on all PM/Admin endpoints (OrgContextGuard)

Even after fixing the auth header issue, `dev-admin-uuid-001` has no `UserOrganization` record in the database. The `OrgContextGuard` threw `AUTH_FORBIDDEN` for any user with no org membership, blocking every PM/Admin endpoint.

**Fix:** Guard now allows users through without org context in non-production. Controllers receive `orgId = undefined` and already handle this gracefully.

### 4. All 25 auth tests were failing

`TokenBlacklistService` was added to `AuthService` for JWT revocation but was never added to the test module providers. Additionally, the `jwtService.sign` assertion used exact object matching, which broke when `jti` was added to the JWT payload.

**Fix:** Added `TokenBlacklistService` mock provider. Updated the sign assertion to use `expect.objectContaining` to tolerate the `jti` field.

### 5. All 11 rental-application tests were failing

`RentalApplicationService` gained `NotificationsService` and `@InjectQueue('ai-screening')` dependencies but the test modules were not updated.

**Fix:** Added `NotificationsService` mock and `getQueueToken('ai-screening')` mock to all three spec files (`submit`, `review-actions`, `convert`).

---

## Verification

| Check | Before | After |
|---|---|---|
| Backend typecheck | ❌ 360 errors (Prisma client not generated) | ✅ 0 errors |
| Auth tests | ❌ 25/25 failing | ✅ 25/25 passing |
| Rental-application tests | ❌ 11/11 failing | ✅ 11/11 passing |
| Payments tests | ✅ 13/15 (unchanged) | ✅ 13/15 |
| keyring-os screening panel | ❌ 404 on every applicant click | ✅ returns PolicyEvaluation |
| keyring-os workspace data | ❌ 401 on all API calls, empty state | ✅ JWT injected, data flows |

---

## Files Changed

| File | Change |
|---|---|
| `src/middleware/dev-mock-auth.middleware.ts` | New — bridges mock headers to JWT auth |
| `src/app.module.ts` | Register `DevMockAuthMiddleware` first in chain |
| `src/common/org-context/org-context.guard.ts` | Dev passthrough for users with no org membership |
| `src/rental-application/rental-application.controller.ts` | Add `GET /:id/policy-evaluation` route |
| `src/rental-application/rental-application.service.ts` | Add `getPolicyEvaluation` method; fix `JsonValue.some` type error |
| `src/auth/auth.service.spec.ts` | Add `TokenBlacklistService` mock; fix `sign` assertion |
| `src/rental-application/rental-application.submit.spec.ts` | Add `NotificationsService` + `BullQueue` mocks |
| `src/rental-application/rental-application.review-actions.spec.ts` | Add `BullQueue` mock |
| `src/rental-application/rental-application.convert.spec.ts` | Add `BullQueue` mock |

---

## Known Remaining Gaps (not in scope for this PR)

- **Action buttons are fake affordances** — Screening Approve/Deny, Payments Remind, Repairs Approve Estimate, Renewals Send Offer, Financials Approve Statement all have no `onClick` handlers. Each needs to be wired to its corresponding backend endpoint.
- **keyring-os has no auth flow** — The admin app has no login page. The mock-header bridge in this PR is a dev-only workaround; a real login flow is needed before any production deployment.
- **BullMQ `ai-screening` worker is not registered** — Jobs are enqueued on application submission but no processor exists to run them.
- **Backend lint** — 28 `prefer-const` and `no-var-requires` errors remain.