### PR TITLE
chore: add secret scanning, large-file guard, hardened .gitignore

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,44 @@
+name: Security Scan
+
+# Secret scanning + large-file guard. Added as part of the 2026-06 security review.
+on:
+  push:
+  pull_request:
+
+jobs:
+  gitleaks:
+    name: Secret scan (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history so gitleaks can scan all commits
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  large-files:
+    name: Reject files larger than 5 MB
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check for oversized tracked files
+        run: |
+          # Fail the build if any tracked file exceeds 5 MB. Use Git LFS for
+          # legitimately large assets, or remove accidental commits.
+          MAX=$((5 * 1024 * 1024))
+          fail=0
+          while IFS= read -r f; do
+            [ -f "$f" ] || continue
+            size=$(wc -c < "$f")
+            if [ "$size" -gt "$MAX" ]; then
+              printf '::error file=%s::%s is %d bytes (>5 MB). Use Git LFS or remove it.\n' "$f" "$f" "$size"
+              fail=1
+            fi
+          done < <(git ls-files)
+          if [ "$fail" -ne 0 ]; then
+            echo "Oversized files detected. See annotations above."
+            exit 1
+          fi
+          echo "No tracked file exceeds 5 MB."

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,37 @@ ops/.env.prod
 # Backend runtime logs
 tenant_portal_backend/logs/
 repomix-output*.xml
+
+# ---- hardened ignore rules (added during 2026-06 security review) ----
+# Secrets: never commit real env files (keep *.example templates)
+.env
+.env.*
+!.env.example
+!.env.*.example
+*.pem
+*.key
+*.p12
+*_private_key*
+*.keystore
+
+# Build artifacts & test output
+dist/
+build/
+coverage/
+test-results/
+playwright-report/
+*.tsbuildinfo
+
+# Logs & noise
+*.log
+debug-storybook.log
+
+# Source dumps (repomix etc.)
+repomix-output*.xml
+
+# Python venvs (if any)
+venv/
+.venv/
+
+# OS / editor
+.DS_Store

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,15 @@
+# ---- gitleaks config (added during 2026-06 security review) ----
+# Uses gitleaks' built-in rules. Add [[rules]] here for project-specific
+# secret shapes, or [allowlist] paths for known-safe files.
+title = "gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Files that are safe to contain secret-like placeholders"
+paths = [
+  '''\.env\.example$''',
+  '''\.env\..*\.example$''',
+  '''(^|/)README\.md$''',
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+# Pre-commit hooks (added during 2026-06 security review)
+# Install: pipx install pre-commit && pre-commit install
+# Run on all files: pre-commit run --all-files
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.4
+    hooks:
+      - id: gitleaks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-added-large-files
+        args: ["--maxkb=5120"]   # reject files >5 MB
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: trailing-whitespace


### PR DESCRIPTION
Adds automated guardrails so the secret/large-file issues found in the 2026-06 review cannot recur.

## What this adds
- **.github/workflows/security-scan.yml** — CI that runs [gitleaks](https://github.com/gitleaks/gitleaks) secret scanning on every push/PR (full history), plus a job that **fails the build if any tracked file exceeds 5 MB**.
- **.gitleaks.toml** — gitleaks config using default rules, allowlisting `*.example` templates and READMEs.
- **.pre-commit-config.yaml** — local pre-commit hooks: gitleaks, `detect-private-key`, and `check-added-large-files` (5 MB cap). Install with `pipx install pre-commit && pre-commit install`.
- **.gitignore** — hardened: ignores real env files (keeps `*.example`), `*.pem`/`*.key`/`*.p12`, build/test artifacts (`dist/`, `coverage/`, `test-results/`, `playwright-report/`), `repomix-output*.xml`, and Python venvs.

## Why
The review found committed secrets / large source dumps across several repos. This makes those mistakes hard to repeat: CI blocks them on PR, and pre-commit blocks them before they are even committed.

No application code changed.