### PR TITLE
fix(e2e): use prisma db push instead of migrate deploy (fixes P3005, unblocks the test gate)

### DIFF
--- a/tenant_portal_backend/test/setup.ts
+++ b/tenant_portal_backend/test/setup.ts
@@ -119,7 +119,15 @@ if (shouldApplyMigrations) {
       console.error('Primary DB error details:', primaryError);
     }
 
-    execSync('npx prisma migrate deploy', {
+    // Sync the (possibly pre-seeded) isolated test schema to the Prisma
+    // schema. We intentionally use `db push` rather than `migrate deploy`:
+    // the block above manually creates a few tables (e.g. RefreshToken) in
+    // the test schema, so `migrate deploy` fails with P3005 ("schema is not
+    // empty") because there is no _prisma_migrations history to baseline
+    // against. `db push` reconciles the live schema to schema.prisma without
+    // needing migration history — the correct tool for ephemeral CI/e2e
+    // databases. --accept-data-loss is safe here: it's a throwaway test DB.
+    execSync('npx prisma db push --skip-generate --accept-data-loss', {
       stdio: 'inherit',
       env: { ...process.env },
     });


### PR DESCRIPTION
## Problem
The Backend CI `test` job's **Run E2E tests** step has been failing for **every backend PR**: all 23 e2e suites die at setup with Prisma **P3005** "The database schema is not empty" (0 tests run). This forced admin-overrides to merge #35/#36/#37.

## Root cause
`test/setup.ts` manually `CREATE`s a few tables (RefreshToken + indexes) in the isolated `tenant_portal_test` schema, **then** runs `npx prisma migrate deploy`. Since the schema is already non-empty and has no `_prisma_migrations` history, `migrate deploy` aborts with P3005 (it refuses to deploy onto an un-baselined non-empty schema).

## Fix
Replace `migrate deploy` with `npx prisma db push --skip-generate --accept-data-loss`. `db push` reconciles the live schema to `schema.prisma` without needing migration history — the canonical approach for ephemeral CI/e2e databases. `--accept-data-loss` is safe (throwaway test DB).

## Verification (local)
Reproduced CI exactly: Postgres in docker, `public` schema pre-migrated (72 migrations). With the fix:
- ✅ **P3005 gone** — `db push` reconciles the schema successfully
- ✅ App boots, e2e suites progress into **actual test execution** (e.g. `POST /auth/register`) — previously they all died at setup
- Remaining local failures are the CI-only `mil` crypto sidecar (`getaddrinfo ENOTFOUND mil`), unrelated to this fix

After this lands, the `test` gate should pass on its own (no more admin-overrides needed for the E2E harness).