### PR TITLE
[verified] harden e2e setup + token-blacklist test (code-review follow-ups)

### DIFF
--- a/tenant_portal_backend/src/auth/revocation/token-blacklist.service.spec.ts
+++ b/tenant_portal_backend/src/auth/revocation/token-blacklist.service.spec.ts
@@ -23,20 +23,26 @@ describe('TokenBlacklistService', () => {
   const prevNodeEnv = process.env.NODE_ENV;
   const prevDisableRedis = process.env.DISABLE_REDIS;
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-    process.env.NODE_ENV = 'development';
-    delete process.env.DISABLE_REDIS;
-  });
-
-  afterAll(() => {
+  const restoreEnv = () => {
     process.env.NODE_ENV = prevNodeEnv;
     if (prevDisableRedis === undefined) {
       delete process.env.DISABLE_REDIS;
     } else {
       process.env.DISABLE_REDIS = prevDisableRedis;
     }
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.NODE_ENV = 'development';
+    delete process.env.DISABLE_REDIS;
   });
+
+  // Restore after EACH test (runs even when a test throws) so a failing test
+  // can't leak the mutated NODE_ENV / DISABLE_REDIS into later suites. afterAll
+  // is kept as a final safety net.
+  afterEach(restoreEnv);
+  afterAll(restoreEnv);
 
   it('initializes and closes redis client', async () => {
     const svc = new TokenBlacklistService(config);

--- a/tenant_portal_backend/test/setup.ts
+++ b/tenant_portal_backend/test/setup.ts
@@ -127,6 +127,15 @@ if (shouldApplyMigrations) {
     // against. `db push` reconciles the live schema to schema.prisma without
     // needing migration history — the correct tool for ephemeral CI/e2e
     // databases. --accept-data-loss is safe here: it's a throwaway test DB.
+    //
+    // Defense-in-depth: --accept-data-loss is destructive, so refuse to run it
+    // against a production database under any circumstance.
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error(
+        'Refusing to run `prisma db push --accept-data-loss` with NODE_ENV=production. ' +
+          'E2E setup must target an ephemeral test database.',
+      );
+    }
     execSync('npx prisma db push --skip-generate --accept-data-loss', {
       stdio: 'inherit',
       env: { ...process.env },


### PR DESCRIPTION
Two non-blocking hardening items surfaced by an **independent pre-commit code review** of the CI-remediation changes (#37/#39). The review PASSED (no security/logic issues); these are the high-value suggestions, applied.

## Changes
1. **test/setup.ts** — guard the destructive `prisma db push --accept-data-loss` with an explicit `NODE_ENV !== 'production'` check. Defense-in-depth: the e2e DB sync can never run against a prod database, even if env is misconfigured. Throws a clear error instead.
2. **token-blacklist.service.spec.ts** — restore `NODE_ENV`/`DISABLE_REDIS` in `afterEach` (not just `afterAll`). `beforeEach` mutates global env; restoring per-test (runs even when a test throws) prevents a failing test from leaking the mutated env into later suites. `afterAll` kept as a final safety net.

## Verification
- token-blacklist suite: 2/2 pass
- setup.ts: compiles clean (tsc)
- Both are test-infra hardening — no production code paths changed.

Skipped two cosmetic suggestions (logger.warn on queue no-op; extra null-guard branch tests) as lower-value.