### PR TITLE
fix(e2e): align auth endpoint status-code expectations with controller (201→200)

### DIFF
--- a/tenant_portal_backend/test/auth.e2e.spec.ts
+++ b/tenant_portal_backend/test/auth.e2e.spec.ts
@@ -325,7 +325,7 @@ describe('Auth API (e2e)', () => {
         const response = await request(app.getHttpServer())
           .post('/auth/mfa/prepare')
           .set('Authorization', `Bearer ${accessToken}`)
-          .expect(201);
+          .expect(200);
 
         expect(response.body).toHaveProperty('secret');
         expect(response.body).toHaveProperty('qrCodeUrl');
@@ -399,7 +399,7 @@ describe('Auth API (e2e)', () => {
           .send({
             username: 'reset@test.com',
           })
-          .expect(201);
+          .expect(200);
 
         expect(response.body.message).toContain('password reset email');
 
@@ -416,7 +416,7 @@ describe('Auth API (e2e)', () => {
           .send({
             username: 'nonexistent@test.com',
           })
-          .expect(201);
+          .expect(200);
 
         expect(response.body.message).toContain('password reset email');
       });
@@ -453,7 +453,7 @@ describe('Auth API (e2e)', () => {
             token: resetToken,
             newPassword: 'NewSecure@Pass456',
           })
-          .expect(201);
+          .expect(200);
 
         expect(response.body.message).toContain('reset successfully');
 
@@ -497,7 +497,7 @@ describe('Auth API (e2e)', () => {
             token: resetToken,
             newPassword: 'NewSecure@Pass456',
           })
-          .expect(201);
+          .expect(200);
 
         // Try to use same token again
         await request(app.getHttpServer())
@@ -562,7 +562,7 @@ describe('Auth API (e2e)', () => {
         .send({
           username: 'security@test.com',
         })
-        .expect(201);
+        .expect(200);
 
       // Password reset may or may not log a security event depending on implementation
       // Just verify forgot-password endpoint works


### PR DESCRIPTION
## Problem
The E2E suite gate had 1 failing suite: auth.e2e (6 tests). All failures are `expected 201 "Created", got 200 "OK"` — the tests\' status-code expectations don\'t match what the AuthController actually returns.

## Root cause
The AuthController uses `@HttpCode(HttpStatus.OK)` (200) for `mfa/prepare`, `forgot-password`, and `reset-password`. Only `register` uses `@HttpCode(HttpStatus.CREATED)` (201). The 6 failing tests expected 201 on those three endpoints — they were written with a different convention than the controller chose.

## Changes
`test/auth.e2e.spec.ts`: 6 `expect(201)` → `expect(200)` on:
- `POST /auth/mfa/prepare` (1 test)
- `POST /auth/forgot-password` (3 tests: valid user, nonexistent user, security event logging)
- `POST /auth/reset-password` (2 tests: valid token, reused token)

## Context
After #42, the E2E gate went from 13 failing suites → only 1 (auth.e2e). This PR clears the last red, making 23/23 E2E suites green. The actual auth-migration work (#40\'s scope of adding JWT auth headers) was already completed by #42 — these 6 tests were just a status-code convention mismatch, not a missing auth issue.

## Verification
- CI will run the full E2E suite — auth.e2e should go from 6 failures → 0
- 22/23 suites already pass; this should make it 23/23